### PR TITLE
Added ROS 2 interface to control Cloud Density parameter

### DIFF
--- a/DemoProject/Levels/HeavyClouds/HeavyClouds.prefab
+++ b/DemoProject/Levels/HeavyClouds/HeavyClouds.prefab
@@ -997,6 +997,10 @@
                                     "ScatteringCoefficient": 0.0689999982714653,
                                     "HenyeyGreensteinG": 0.5
                                 }
+                            },
+                            "CloudDensityTopicConfiguration": {
+                                "Type": "std_msgs::msg::Float32",
+                                "Topic": "some/topic"
                             }
                         }
                     }
@@ -1035,6 +1039,13 @@
                 "EditorVisibilityComponent": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 10817530613718184900
+                },
+                "ROS2FrameComponent": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 2174984008678663565,
+                    "m_template": {
+                        "$type": "ROS2FrameComponent"
+                    }
                 },
                 "TransformComponent": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/DemoProject/project.json
+++ b/DemoProject/project.json
@@ -33,6 +33,7 @@
         "Profiler",
         "PythonAssetBuilder",
         "QtForPython",
+        "ROS2==2.0.0",
         "RemoteTools",
         "SceneProcessing",
         "ScriptedEntityTweener",

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -57,7 +57,7 @@ ly_add_target(
             AZ::AzFramework
             Gem::Atom_RPI.Public
             Gem::AtomLyIntegration_CommonFeatures.Public
-
+            Gem::ROS2.Static
 )
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
@@ -78,6 +78,8 @@ ly_add_target(
         PRIVATE
             Gem::${gem_name}.Private.Object
 )
+
+target_depends_on_ros2_packages(${gem_name}.Private.Object std_msgs)
 
 # By default, we will specify that the above target ${gem_name} would be used by
 # Client and Server type targets when this gem is enabled.  If you don't want it
@@ -129,6 +131,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::Atom_Feature_Common.Public
                 Gem::AtomLyIntegration_CommonFeatures.Public
                 Gem::Atom_Utils.Static
+                Gem::ROS2.Static
     )
 
     ly_add_target(

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponent.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponent.cpp
@@ -26,4 +26,15 @@ namespace VolumetricClouds
         }
 
     }
+
+    void CloudscapeComponent::Activate()
+    {
+        BaseClass::Activate();
+        m_controller.CreateCloudDensitySubscriptionHandler(GetEntity());
+    }
+
+    void CloudscapeComponent::Deactivate()
+    {
+        BaseClass::Deactivate();
+    }
 } // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponent.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponent.cpp
@@ -36,5 +36,6 @@ namespace VolumetricClouds
     void CloudscapeComponent::Deactivate()
     {
         BaseClass::Deactivate();
+        m_controller.DestroyCloudDensitySubscriptionHandler();
     }
 } // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponent.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponent.h
@@ -22,7 +22,10 @@ namespace VolumetricClouds
     
         CloudscapeComponent() = default;
         CloudscapeComponent(const CloudscapeComponentConfig& config);
-    
+
+        void Activate() override;
+        void Deactivate() override;
+
         static void Reflect(AZ::ReflectContext* context);
     };
 } // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
@@ -19,6 +19,12 @@
 
 namespace VolumetricClouds
 {
+        CloudscapeComponentConfig::CloudscapeComponentConfig()
+        {
+            m_cloudDensityTopicConfiguration.m_type = "std_msgs::msg::Float32";
+            m_cloudDensityTopicConfiguration.m_topic = "clouds/density";
+        }
+
         void CloudscapeComponentConfig::Reflect(AZ::ReflectContext* context)
         {
             CloudscapeShaderConstantData::Reflect(context);
@@ -224,9 +230,6 @@ namespace VolumetricClouds
                 AZ::Data::AssetBus::Handler::BusConnect(textureAssetId);
                 m_configuration.m_weatherMap.QueueLoad();
             }
-
-            m_configuration.m_cloudDensityTopicConfiguration.m_type = "std_msgs::msg::Float32";
-            m_configuration.m_cloudDensityTopicConfiguration.m_topic = "clouds/density";
 
             m_prevConfiguration = m_configuration;
             EnableFeatureProcessor();

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
@@ -226,6 +226,7 @@ namespace VolumetricClouds
             }
 
             m_configuration.m_cloudDensityTopicConfiguration.m_type = "std_msgs::msg::Float32";
+            m_configuration.m_cloudDensityTopicConfiguration.m_topic = "clouds/density";
 
             m_prevConfiguration = m_configuration;
             EnableFeatureProcessor();
@@ -747,6 +748,15 @@ namespace VolumetricClouds
                         ProcessCloudDensityMessage(message);
                     });
             m_subscriptionHandler->Activate(entity, m_configuration.m_cloudDensityTopicConfiguration);
+        }
+
+        void CloudscapeComponentController::DestroyCloudDensitySubscriptionHandler()
+        {
+            if (m_subscriptionHandler)
+            {
+                m_subscriptionHandler->Deactivate();
+                m_subscriptionHandler.reset();
+            }
         }
 
 } // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
@@ -32,7 +32,8 @@ namespace VolumetricClouds
                     ->Field("SunEntity", &CloudscapeComponentConfig::m_sunEntity)
                     ->Field("WeatherMap", &CloudscapeComponentConfig::m_weatherMap)
                     ->Field("ShaderConstantData", &CloudscapeComponentConfig::m_shaderConstantData)
-                    ->Field("Sunlight intensity cutoff", &CloudscapeComponentConfig::m_sunlightIntensityCutOff);
+                    ->Field("Sunlight intensity cutoff", &CloudscapeComponentConfig::m_sunlightIntensityCutOff)
+                    ->Field("CloudDensityTopicConfiguration", &CloudscapeComponentConfig::m_cloudDensityTopicConfiguration);
 
                 if (auto editContext = serializeContext->GetEditContext())
                 {
@@ -70,7 +71,13 @@ namespace VolumetricClouds
                             "Sunlight intensity change range",
                             "Range used to modify the sunlight intensity based on the sun's position during sunset and sunrise.")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
-                        ->Attribute(AZ::Edit::Attributes::Max, 0.25f);
+                        ->Attribute(AZ::Edit::Attributes::Max, 0.25f)
+                        ->DataElement(
+                            AZ::Edit::UIHandlers::Default,
+                            &CloudscapeComponentConfig::m_cloudDensityTopicConfiguration,
+                            "Cloud density topic configuration",
+                            "Configuration of the ROS2 topic to which the component subscribes."
+                        );
                 }
             }
         }
@@ -218,6 +225,8 @@ namespace VolumetricClouds
                 m_configuration.m_weatherMap.QueueLoad();
             }
 
+            m_configuration.m_cloudDensityTopicConfiguration.m_type = "std_msgs::msg::Float32";
+
             m_prevConfiguration = m_configuration;
             EnableFeatureProcessor();
 
@@ -247,6 +256,12 @@ namespace VolumetricClouds
                 m_scene->DisableFeatureProcessor<CloudscapeFeatureProcessor>();
                 m_cloudscapeFeatureProcessor = nullptr;
                 m_scene = nullptr;
+            }
+
+            if (m_subscriptionHandler)
+            {
+                m_subscriptionHandler->Deactivate();
+                m_subscriptionHandler.reset();
             }
             m_isActive = false;
         }
@@ -500,6 +515,11 @@ namespace VolumetricClouds
             }
         }
 
+        void CloudscapeComponentController::ProcessCloudDensityMessage(const std_msgs::msg::Float32& message)
+        {
+            SetCloudDensity(message.data);
+        }
+
         //! RPI::ViewportContextIdNotificationBus
         void CloudscapeComponentController::OnViewportSizeChanged([[maybe_unused]] AzFramework::WindowSize size)
         {
@@ -660,6 +680,11 @@ namespace VolumetricClouds
 
         void CloudscapeComponentController::SetCloudDensity(float density)
         {
+            if (density < 0.0f || density > 1.0f)
+            {
+                AZ_Error("CloudscapeComponentController", false, "Cloud density to be set is not in range [0.0, 1.0]. Value: %f", density);
+                return;
+            }
             m_configuration.m_shaderConstantData.m_globalCloudDensity = density;
             SubmitShaderConstantData();
         }
@@ -713,5 +738,15 @@ namespace VolumetricClouds
         }
         // VolumetricCloudsRequestBus::Handler overrides END
         /////////////////////////////////////////////////////////
+
+        void CloudscapeComponentController::CreateCloudDensitySubscriptionHandler(const AZ::Entity* entity)
+        {
+            m_subscriptionHandler = AZStd::make_unique<CloudscapeSubscriptionHandler>(
+                    [this](const std_msgs::msg::Float32& message)
+                    {
+                        ProcessCloudDensityMessage(message);
+                    });
+            m_subscriptionHandler->Activate(entity, m_configuration.m_cloudDensityTopicConfiguration);
+        }
 
 } // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
@@ -259,11 +259,8 @@ namespace VolumetricClouds
                 m_scene = nullptr;
             }
 
-            if (m_subscriptionHandler)
-            {
-                m_subscriptionHandler->Deactivate();
-                m_subscriptionHandler.reset();
-            }
+            DestroyCloudDensitySubscriptionHandler();
+
             m_isActive = false;
         }
 

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
@@ -130,6 +130,7 @@ namespace VolumetricClouds
         /////////////////////////////////////////////////////////
 
         void CreateCloudDensitySubscriptionHandler(const AZ::Entity* entity);
+        void DestroyCloudDensitySubscriptionHandler();
 
     private:
         AZ_DISABLE_COPY(CloudscapeComponentController);

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
@@ -19,6 +19,10 @@
 #include <VolumetricClouds/CloudTextureProviderBus.h>
 #include <Renderer/CloudscapeShaderConstantData.h>
 
+#include "CloudscapeSubscriptionHandler.h"
+#include <ROS2/Communication/TopicConfiguration.h>
+
+
 namespace AZ::RPI
 {
     class Scene;
@@ -55,6 +59,7 @@ namespace VolumetricClouds
 
         // Used to modify the sunlight intensity based on the sun's position during sunset and sunrise.
         float m_sunlightIntensityCutOff = 0.025f;
+        ROS2::TopicConfiguration m_cloudDensityTopicConfiguration;
     };
     
 
@@ -124,6 +129,8 @@ namespace VolumetricClouds
         // VolumetricCloudsRequestBus::Handler overrides END
         /////////////////////////////////////////////////////////
 
+        void CreateCloudDensitySubscriptionHandler(const AZ::Entity* entity);
+
     private:
         AZ_DISABLE_COPY(CloudscapeComponentController);
         static constexpr char LogName[] = "CloudscapeComponentController";
@@ -133,6 +140,8 @@ namespace VolumetricClouds
 
         void FetchAllSunLightData();
         void NotifySunLightDataChanged();
+
+        void ProcessCloudDensityMessage(const std_msgs::msg::Float32& message);
 
         // A helper function that makes sure the shader constant data
         // make sense and are clamped within good boundaries before being sent to the
@@ -175,6 +184,8 @@ namespace VolumetricClouds
         CloudscapeFeatureProcessor* m_cloudscapeFeatureProcessor = nullptr;
 
         AZ::Render::DirectionalLightConfigurationChangedEvent::Handler m_directionalLightConfigChangedEventHandler;
+
+        AZStd::unique_ptr<ROS2::IControlSubscriptionHandler> m_subscriptionHandler;
 
         float m_sunLightIntensity = 1.0f;
     };

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
@@ -41,6 +41,7 @@ namespace VolumetricClouds
         AZ_RTTI(CloudscapeComponentConfig, "{6E894FEA-BAE8-4089-B76D-B082C4A5B394}", AZ::ComponentConfig);
         AZ_CLASS_ALLOCATOR(CloudscapeComponentConfig, AZ::SystemAllocator);
 
+        CloudscapeComponentConfig();
         virtual ~CloudscapeComponentConfig() = default;
         static void Reflect(AZ::ReflectContext* context);
         

--- a/Gem/Code/Source/Clients/Components/CloudscapeSubscriptionHandler.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeSubscriptionHandler.cpp
@@ -1,0 +1,15 @@
+#include "CloudscapeSubscriptionHandler.h"
+#include <VolumetricClouds/VolumetricCloudsBus.h>
+
+namespace VolumetricClouds
+{
+    CloudscapeSubscriptionHandler::CloudscapeSubscriptionHandler(MessageCallback messageCallback)
+        : m_messageCallback(AZStd::move(messageCallback))
+    {
+    };
+
+    void CloudscapeSubscriptionHandler::SendToBus(const std_msgs::msg::Float32& message)
+    {
+        m_messageCallback(message);
+    }
+} // namespace VolumetricClouds

--- a/Gem/Code/Source/Clients/Components/CloudscapeSubscriptionHandler.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeSubscriptionHandler.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ROS2/RobotControl/ControlSubscriptionHandler.h>
+#include <std_msgs/msg/float32.hpp>
+
+namespace VolumetricClouds
+{
+    class CloudscapeSubscriptionHandler : public ROS2::ControlSubscriptionHandler<std_msgs::msg::Float32>
+    {
+    public:
+        using MessageCallback = AZStd::function<void(const std_msgs::msg::Float32&)>;
+
+        explicit CloudscapeSubscriptionHandler(MessageCallback messageCallback);
+
+    private:
+        // ROS2::ControlSubscriptionHandler overrides
+        void SendToBus(const std_msgs::msg::Float32& message) override;
+
+        MessageCallback m_messageCallback;
+    };
+} // VolumetricClouds

--- a/Gem/Code/Source/Tools/Components/EditorCloudscapeComponent.cpp
+++ b/Gem/Code/Source/Tools/Components/EditorCloudscapeComponent.cpp
@@ -48,6 +48,11 @@ namespace VolumetricClouds
 
         }
 
+        void EditorCloudscapeComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType &required)
+        {
+            required.push_back(AZ_CRC_CE("ROS2Frame"));
+        }
+
         EditorCloudscapeComponent::EditorCloudscapeComponent(const CloudscapeComponentConfig& config)
             : BaseClass(config)
         {

--- a/Gem/Code/Source/Tools/Components/EditorCloudscapeComponent.h
+++ b/Gem/Code/Source/Tools/Components/EditorCloudscapeComponent.h
@@ -22,6 +22,8 @@ namespace VolumetricClouds
         AZ_EDITOR_COMPONENT(EditorCloudscapeComponent, EditorCloudscapeComponentTypeId, BaseClass);
     
         static void Reflect(AZ::ReflectContext* context);
+
+        static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
     
         EditorCloudscapeComponent() = default;
         EditorCloudscapeComponent(const CloudscapeComponentConfig& config);

--- a/Gem/Code/volumetricclouds_private_files.cmake
+++ b/Gem/Code/volumetricclouds_private_files.cmake
@@ -21,6 +21,8 @@ set(FILES
     Source/Clients/Components/CloudscapeComponent.h
     Source/Clients/Components/CloudscapeComponentController.cpp
     Source/Clients/Components/CloudscapeComponentController.h
+    Source/Clients/Components/CloudscapeSubscriptionHandler.cpp
+    Source/Clients/Components/CloudscapeSubscriptionHandler.h
     Source/Renderer/CloudTextureComputePipeline.cpp
     Source/Renderer/CloudTextureComputePipeline.h
     Source/Renderer/CloudTexturesDebugViewerFeatureProcessor.cpp


### PR DESCRIPTION
## What does this PR do?

This PR adds ROS 2 interface which allows to change the value of `Cloud Density` parameter via ROS 2 messages.

## How was this PR tested?

By using the modified component in the editor and publishing ROS 2 messages on proper topic.

## Screenshots

![image](https://github.com/michalpelka/VolumetricCloudsForO3DE/assets/37815610/efc51382-c803-4105-8be0-026cd0348114)

