### PR TITLE
Add NotifySunLightDataChanged to clouds EBus

### DIFF
--- a/Gem/Code/Include/VolumetricClouds/VolumetricCloudsBus.h
+++ b/Gem/Code/Include/VolumetricClouds/VolumetricCloudsBus.h
@@ -65,6 +65,9 @@ namespace VolumetricClouds
 
         // Submits the current state of the parameters to the renderer.
         virtual void EndCallBatch() = 0;
+
+        // Notifies the renderer that the sun light data has changed.
+        virtual void NotifySunLightDataChanged() = 0;
     };
 
     class VolumetricCloudsBusTraits : public AZ::EBusTraits

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.cpp
@@ -161,6 +161,7 @@ namespace VolumetricClouds
                     // Cloud Material Properties
                     ->Event("GetCloudMaterialProperties", &VolumetricCloudsRequestBus::Events::GetCloudMaterialProperties)
                     ->Event("SetCloudMaterialProperties", &VolumetricCloudsRequestBus::Events::SetCloudMaterialProperties)
+                    ->Event("NotifySunLightDataChanged", &VolumetricCloudsRequestBus::Events::NotifySunLightDataChanged);
                     ;
             }
         }

--- a/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
+++ b/Gem/Code/Source/Clients/Components/CloudscapeComponentController.h
@@ -141,7 +141,7 @@ namespace VolumetricClouds
         void EnableFeatureProcessor();
 
         void FetchAllSunLightData();
-        void NotifySunLightDataChanged();
+        void NotifySunLightDataChanged() override;
 
         void ProcessCloudDensityMessage(const std_msgs::msg::Float32& message);
 


### PR DESCRIPTION
I've added a new event to the clouds Ebus. This Ebus enables the user to update the clouds when the sun configuration changes during runtime.