### PR TITLE
Multi pipeline support

### DIFF
--- a/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.cpp
+++ b/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.cpp
@@ -1,14 +1,14 @@
 /*
-* Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
 #include <AzCore/Name/NameDictionary.h>
 
-#include <Atom/RHI/DrawPacketBuilder.h>
 #include <Atom/RHI.Reflect/InputStreamLayoutBuilder.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
 
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 #include <Atom/RPI.Public/RenderPipeline.h>
@@ -16,18 +16,22 @@
 #include <Atom/RPI.Public/RPIUtils.h>
 #include <Atom/RPI.Reflect/Asset/AssetUtils.h> // FIXME: Try removing
 
+#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 #include <Atom/RPI.Public/Pass/PassFilter.h>
 #include <Atom/RPI.Public/Pass/RasterPass.h>
-#include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/View.h>
 #include <Atom/RPI.Public/ViewportContext.h>
-#include <Atom/RPI.Public/Image/ImageSystemInterface.h>
 
 #include <Renderer/Passes/CloudscapeComputePass.h>
 #include <Renderer/Passes/CloudscapeRenderPass.h>
 // #include <Renderer/Passes/DepthBufferCopyPass.h>
+#include "AzCore/Name/Name.h"
 #include "CloudscapeFeatureProcessor.h"
+
+#include <iostream>
+#include <sys/types.h>
 
 namespace VolumetricClouds
 {
@@ -35,9 +39,7 @@ namespace VolumetricClouds
     {
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
-            serializeContext
-                ->Class<CloudscapeFeatureProcessor, AZ::RPI::FeatureProcessor>()
-                ->Version(1);
+            serializeContext->Class<CloudscapeFeatureProcessor, AZ::RPI::FeatureProcessor>()->Version(1);
         }
     }
 
@@ -50,38 +52,106 @@ namespace VolumetricClouds
 
     void CloudscapeFeatureProcessor::Deactivate()
     {
-        if (m_cloudscapeComputePass)
+        for (unsigned int i = 0; i < m_cloudscapeComputePasses.size(); i++)
         {
-            // This is necessary to avoid pesky error messages of invalid attachments when
-            // the feature processor is being destroyed.
-            m_cloudscapeComputePass->QueueForRemoval();
-            m_cloudscapeReprojectionPass->QueueForRemoval();
-            m_cloudscapeRenderPass->QueueForRemoval();
-            //m_depthBufferCopyPass->QueueForRemoval();
+            if (m_cloudscapeComputePasses[i])
+            {
+                // This is necessary to avoid pesky error messages of invalid attachments when
+                // the feature processor is being destroyed.
+                // m_cloudscapeComputePasses[i]->QueueForRemoval();
+                // m_cloudscapeReprojectionPasses[i]->QueueForRemoval();
+                // m_cloudscapeRenderPasses[i]->QueueForRemoval();
+                // m_depthBufferCopyPass->QueueForRemoval();
+            }
         }
-
         DisableSceneNotification();
-        m_viewportSize = { 0,0 };
+        m_viewportSize = { 0, 0 };
+        m_viewToIndexMap.clear();
     }
 
     void CloudscapeFeatureProcessor::Simulate(const SimulatePacket&)
     {
-        if (m_cloudscapeComputePass)
+        // if (m_cloudscapeComputePass)
+        // {
+        //     std::cout << "CloudscapeFeatureProcessor::Simulate frame " << m_frameCounter << std::endl;
+
+        //     m_cloudscapeComputePass->UpdateFrameCounter(m_frameCounter);
+
+        //     const auto& passSrg = m_cloudscapeReprojectionPass->GetShaderResourceGroup();
+        //     const uint32_t pixelIndex4x4 = m_frameCounter % 16;
+        //     passSrg->SetConstant(m_pixelIndex4x4Index, pixelIndex4x4);
+
+        //     m_cloudscapeRenderPass->UpdateFrameCounter(m_frameCounter);
+
+        //     m_frameCounter++;
+        // }
+    }
+
+    void CloudscapeFeatureProcessor::Render(const RenderPacket& renderPacket)
+    {
+        // for (const auto& view : renderPacket.m_views)
+        // {
+        //     // std::cout << "View: " << view->GetName().GetCStr() << std::endl;
+        // }
+
+        AZStd::set<uint32_t> updates;
+
+        for (const auto& view : renderPacket.m_views)
         {
-            m_cloudscapeComputePass->UpdateFrameCounter(m_frameCounter);
+            if (m_viewToIndexMap.find(view) != m_viewToIndexMap.end())
+            {
+                updates.insert(m_viewToIndexMap[view]);
+            }
+        }
+        for (const auto index : updates)
+        {
+            if (m_cloudscapeComputePasses[index])
+            {
+                // std::cout << "CloudscapeFeatureProcessor::Render frame " << m_frameCounter << std::endl;
+                uint32_t pixelIndex = m_cloudscapeComputePasses[index]->GetPixelIndex();
+                pixelIndex++;
+                m_cloudscapeComputePasses[index]->UpdateFrameCounter(pixelIndex);
+                std::cout << "Render: " << index << " frame: " << pixelIndex << std::endl;
 
-            const auto& passSrg = m_cloudscapeReprojectionPass->GetShaderResourceGroup();
-            const uint32_t pixelIndex4x4 = m_frameCounter % 16;
-            passSrg->SetConstant(m_pixelIndex4x4Index, pixelIndex4x4);
+                const auto& passSrg = m_cloudscapeReprojectionPasses[index]->GetShaderResourceGroup();
+                const uint32_t pixelIndex4x4 = pixelIndex % 16;
+                passSrg->SetConstant(m_pixelIndex4x4Index, pixelIndex4x4);
 
-            m_cloudscapeRenderPass->UpdateFrameCounter(m_frameCounter);
-            
-            m_frameCounter++;
+                m_cloudscapeRenderPasses[index]->UpdateFrameCounter(pixelIndex);
+            }
         }
     }
 
     void CloudscapeFeatureProcessor::AddRenderPasses([[maybe_unused]] AZ::RPI::RenderPipeline* renderPipeline)
     {
+        uint32_t width;
+        uint32_t height;
+
+        // Getting the viewport size for the main pipeline as the target render sizes are note set in the render settings.
+        if (renderPipeline->GetDescriptor().m_name == "MainPipeline_0")
+        {
+            width = m_viewportSize.m_width;
+            height = m_viewportSize.m_height;
+        }
+        else
+        {
+            width = renderPipeline->GetRenderSettings().m_size.m_width;
+            height = renderPipeline->GetRenderSettings().m_size.m_height;
+        }
+
+        std::cout << "CloudscapeFeatureProcessor::AddRenderPasses width " << width << " height " << height << std::endl;
+        std::cout << "Default view: " << renderPipeline->GetDefaultView()->GetName().GetCStr() << std::endl;
+
+        // std::cout << "CloudscapeFeatureProcessor::AddRenderPasses summary" << std::endl;
+        // std::cout << "CloudscapeComputePasses: " << m_cloudscapeComputePasses.size() << std::endl;
+        // std::cout << "CloudscapeReprojectionPasses: " << m_cloudscapeReprojectionPasses.size() << std::endl;
+        // std::cout << "CloudscapeRenderPasses: " << m_cloudscapeRenderPasses.size() << std::endl;
+        // std::cout << "ViewToIndexMap: " << m_viewToIndexMap.size() << std::endl;
+
+        m_viewToIndexMap[renderPipeline->GetDefaultView()] = m_cloudscapeComputePasses.size();
+
+        m_cloudOutputPairs.push_back({ CreateCloudscapeOutputAttachment(AZ::Name("CloudscapeOutput0"), { width, height }),
+                                       CreateCloudscapeOutputAttachment(AZ::Name("CloudscapeOutput1"), { width, height }) });
         // Get the pass requests to create passes from the asset
         AddPassRequestToRenderPipeline(renderPipeline, "Passes/CloudscapeComputePassRequest.azasset", "DepthPrePass", false /*before*/);
         // Hold a reference to the compute pass
@@ -89,34 +159,36 @@ namespace VolumetricClouds
             const auto passName = AZ::Name("CloudscapeComputePass");
             AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(passName, renderPipeline);
             AZ::RPI::Pass* existingPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
-            m_cloudscapeComputePass = azrtti_cast<CloudscapeComputePass*>(existingPass);
-            if (!m_cloudscapeComputePass)
+            m_cloudscapeComputePasses.push_back(azrtti_cast<CloudscapeComputePass*>(existingPass));
+            // m_cloudscapeComputePass.
+            if (!m_cloudscapeComputePasses.back())
             {
                 AZ_Error(LogName, false, "%s Failed to find as RenderPass: %s", __FUNCTION__, passName.GetCStr());
                 return;
             }
+            m_cloudscapeComputePasses.back()->SetPassIndex(m_cloudscapeComputePasses.size() - 1);
 
             if (m_shaderConstantData)
             {
-                m_cloudscapeComputePass->UpdateShaderConstantData(*m_shaderConstantData);
+                m_cloudscapeComputePasses.back()->UpdateShaderConstantData(*m_shaderConstantData);
             }
         }
 
-        AddPassRequestToRenderPipeline(renderPipeline, "Passes/CloudscapeReprojectionComputePassRequest.azasset", "MotionVectorPass", false /*before*/);
+        AddPassRequestToRenderPipeline(
+            renderPipeline, "Passes/CloudscapeReprojectionComputePassRequest.azasset", "MotionVectorPass", false /*before*/);
         // Hold a reference to the compute pass
         {
             const auto passName = AZ::Name("CloudscapeReprojectionComputePass");
             AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(passName, renderPipeline);
             AZ::RPI::Pass* existingPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
-            m_cloudscapeReprojectionPass = azrtti_cast<AZ::RPI::ComputePass*>(existingPass);
-            if (!m_cloudscapeReprojectionPass)
+            m_cloudscapeReprojectionPasses.push_back(azrtti_cast<AZ::RPI::ComputePass*>(existingPass));
+            if (!m_cloudscapeReprojectionPasses.back())
             {
                 AZ_Error(LogName, false, "%s Failed to find as RenderPass: %s", __FUNCTION__, passName.GetCStr());
                 return;
             }
-            m_cloudscapeReprojectionPass->SetTargetThreadCounts(m_viewportSize.m_width, m_viewportSize.m_height, 1);
+            m_cloudscapeReprojectionPasses.back()->SetTargetThreadCounts(width, height, 1);
         }
-
 
         AddPassRequestToRenderPipeline(renderPipeline, "Passes/CloudscapeRenderPassRequest.azasset", "TransparentPass", true /*before*/);
         // Hold a reference to the render pass
@@ -124,34 +196,34 @@ namespace VolumetricClouds
             const auto passName = AZ::Name("CloudscapeRenderPass");
             AZ::RPI::PassFilter passFilter = AZ::RPI::PassFilter::CreateWithPassName(passName, renderPipeline);
             AZ::RPI::Pass* existingPass = AZ::RPI::PassSystemInterface::Get()->FindFirstPass(passFilter);
-            m_cloudscapeRenderPass = azrtti_cast<CloudscapeRenderPass*>(existingPass);
-            if (!m_cloudscapeRenderPass)
+            m_cloudscapeRenderPasses.push_back(azrtti_cast<CloudscapeRenderPass*>(existingPass));
+            if (!m_cloudscapeRenderPasses.back())
             {
                 AZ_Error(LogName, false, "%s Failed to find as RenderPass: %s", __FUNCTION__, passName.GetCStr());
                 return;
             }
         }
-
     }
 
     //! AZ::RPI::FeatureProcessor overrides END ...
     /////////////////////////////////////////////////////////////////////////////
-
 
     /////////////////////////////////////////////////////////////////////
     //! Functions called by CloudscapeComponentController START
     void CloudscapeFeatureProcessor::UpdateShaderConstantData(const CloudscapeShaderConstantData& shaderData)
     {
         m_shaderConstantData = &shaderData;
-        if (m_cloudscapeComputePass)
+        for (unsigned int i = 0; i < m_cloudscapeComputePasses.size(); i++)
         {
-            m_cloudscapeComputePass->UpdateShaderConstantData(shaderData);
+            if (m_cloudscapeComputePasses[i])
+            {
+                m_cloudscapeComputePasses[i]->UpdateShaderConstantData(shaderData);
+            }
         }
     }
 
     //! Functions called by CloudscapeComponentController END
     /////////////////////////////////////////////////////////////////////
-
 
     void CloudscapeFeatureProcessor::ActivateInternal()
     {
@@ -159,18 +231,12 @@ namespace VolumetricClouds
         auto viewportContext = viewportContextInterface->GetViewportContextByScene(GetParentScene());
         m_viewportSize = viewportContext->GetViewportSize();
 
-        m_cloudOutput0 = CreateCloudscapeOutputAttachment(AZ::Name("CloudscapeOutput0"), m_viewportSize);
-        AZ_Assert(!!m_cloudOutput0, "Failed to create CloudscapeOutput0");
-        m_cloudOutput1 = CreateCloudscapeOutputAttachment(AZ::Name("CloudscapeOutput1"), m_viewportSize);
-        AZ_Assert(!!m_cloudOutput1, "Failed to create CloudscapeOutput1");
-
         DisableSceneNotification();
         EnableSceneNotification();
     }
 
-
-    AZ::Data::Instance<AZ::RPI::AttachmentImage> CloudscapeFeatureProcessor::CreateCloudscapeOutputAttachment(const AZ::Name& attachmentName
-        , const AzFramework::WindowSize attachmentSize) const
+    AZ::Data::Instance<AZ::RPI::AttachmentImage> CloudscapeFeatureProcessor::CreateCloudscapeOutputAttachment(
+        const AZ::Name& attachmentName, const AzFramework::WindowSize attachmentSize) const
     {
         AZ::RHI::ImageDescriptor imageDesc = AZ::RHI::ImageDescriptor::Create2D(
             AZ::RHI::ImageBindFlags::ShaderReadWrite, attachmentSize.m_width, attachmentSize.m_height, AZ::RHI::Format::R8G8B8A8_UNORM);

--- a/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.h
+++ b/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.h
@@ -104,6 +104,7 @@ namespace VolumetricClouds
 
         // View to pass index map used when updating the pixel index of the passes.
         AZStd::map<AZ::RPI::ViewPtr, uint32_t> m_viewToIndexMap;
+        AZStd::map<AZ::RPI::RenderPipeline*, uint32_t> m_renderPipelineToIndexMap;
 
         // Shader constants for m_cloudscapeReprojectionPass
         AZ::RHI::ShaderInputNameIndex m_pixelIndex4x4Index = "m_pixelIndex4x4";

--- a/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.h
+++ b/Gem/Code/Source/Renderer/CloudscapeFeatureProcessor.h
@@ -7,17 +7,17 @@
 
 #pragma once
 
-#include "Atom/RPI.Public/Base.h"
-#include "AzCore/Name/Name.h"
-#include "AzCore/std/containers/vector.h"
-#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
+#include <AzCore/Name/Name.h>
+#include <AzCore/std/containers/vector.h>
 
+#include <Atom/RPI.Public/Base.h>
 #include <Atom/RPI.Public/Buffer/Buffer.h>
 #include <Atom/RPI.Public/FeatureProcessor.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/PipelineState.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
 #include <Atom/RPI.Public/ViewportContextBus.h>
+#include <Atom/RPI.Reflect/Image/StreamingImageAsset.h>
 
 #include <Renderer/CloudTexturePresentationData.h>
 #include <Renderer/CloudscapeShaderConstantData.h>
@@ -74,7 +74,6 @@ namespace VolumetricClouds
         //! AZ::RPI::FeatureProcessor overrides START...
         void Activate() override;
         void Deactivate() override;
-        void Simulate(const SimulatePacket&) override;
         void Render(const RenderPacket& renderPacket) override;
         void AddRenderPasses(AZ::RPI::RenderPipeline* renderPipeline) override;
         //! AZ::RPI::FeatureProcessor overrides END ...
@@ -83,6 +82,7 @@ namespace VolumetricClouds
         static constexpr const char* FeatureProcessorName = "CloudscapeFeatureProcessor";
 
         // There are two fullscreen sized "render attachments" for the cloudscape.
+        // These attachments exist per render pipeline.
         // They are owned by this feature processor.
         // Each frame one of the attachments is the current attachment and the other
         // represents the previous frame. This means that for all the passes involved
@@ -102,6 +102,7 @@ namespace VolumetricClouds
         AZStd::vector<AZ::RPI::ComputePass*> m_cloudscapeReprojectionPasses;
         AZStd::vector<CloudscapeRenderPass*> m_cloudscapeRenderPasses;
 
+        // View to pass index map used when updating the pixel index of the passes.
         AZStd::map<AZ::RPI::ViewPtr, uint32_t> m_viewToIndexMap;
 
         // Shader constants for m_cloudscapeReprojectionPass

--- a/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.cpp
+++ b/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.cpp
@@ -16,10 +16,9 @@
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/PipelineState.h>
 
-#include "CloudscapeComputePass.h"
 #include <Renderer/CloudscapeFeatureProcessor.h>
 
-#include <iostream>
+#include "CloudscapeComputePass.h"
 
 namespace VolumetricClouds
 {
@@ -83,7 +82,6 @@ namespace VolumetricClouds
             // This can happen when the feature processor is being destroyed.
             return;
         }
-        std::cout << m_passIndex << std::endl;
         const auto output0ImageAttachment = cloudscapeFeatureProcessor->GetOutput0ImageAttachment(m_passIndex);
         // Bind the first attachment
         SetImageAttachmentBinding(0, output0ImageAttachment);
@@ -125,9 +123,6 @@ namespace VolumetricClouds
             GetPathName().GetCStr());
 
         m_shaderResourceGroup->SetConstant(m_pixelIndex4x4Index, m_pixelIndex4x4);
-        // m_pixelIndex4x4 += 1;
-        // m_pixelIndex4x4 %= 16;
-        // std::cout << "Pass" << m_pixelIndex4x4 << std::endl;
 
         if (m_srgNeedsUpdate && m_shaderConstantData)
         {

--- a/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.cpp
+++ b/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.cpp
@@ -1,33 +1,35 @@
 /*
-* Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 
-#include <Atom/RPI.Public/RenderPipeline.h>
-#include <Atom/RPI.Public/View.h>
-#include <Atom/RPI.Public/Scene.h>
-#include <Atom/RPI.Public/Pass/PassFilter.h>
-#include <Atom/RPI.Public/Pass/PassSystem.h>
 #include <Atom/RPI.Public/Image/AttachmentImagePool.h>
 #include <Atom/RPI.Public/Image/ImageSystemInterface.h>
+#include <Atom/RPI.Public/Pass/PassFilter.h>
+#include <Atom/RPI.Public/Pass/PassSystem.h>
+#include <Atom/RPI.Public/RenderPipeline.h>
+#include <Atom/RPI.Public/Scene.h>
+#include <Atom/RPI.Public/View.h>
 
 #include <Atom/RHI/FrameScheduler.h>
 #include <Atom/RHI/PipelineState.h>
 
-#include <Renderer/CloudscapeFeatureProcessor.h>
 #include "CloudscapeComputePass.h"
+#include <Renderer/CloudscapeFeatureProcessor.h>
+
+#include <iostream>
 
 namespace VolumetricClouds
 {
-    
+
     AZ::RPI::Ptr<CloudscapeComputePass> CloudscapeComputePass::Create(const AZ::RPI::PassDescriptor& descriptor)
     {
         AZ::RPI::Ptr<CloudscapeComputePass> pass = aznew CloudscapeComputePass(descriptor);
         return pass;
     }
-    
+
     CloudscapeComputePass::CloudscapeComputePass(const AZ::RPI::PassDescriptor& descriptor)
         : AZ::RPI::ComputePass(descriptor)
     {
@@ -36,19 +38,20 @@ namespace VolumetricClouds
     CloudscapeComputePass::~CloudscapeComputePass()
     {
         // Left this here, in case there are bugs that pop up related with destruction of the passes related with rendering clouds.
-        //AZ_Printf("ERASEME", "%s\n", __FUNCTION__);
+        // AZ_Printf("ERASEME", "%s\n", __FUNCTION__);
     }
-    
+
     void CloudscapeComputePass::InitializeInternal()
     {
         AZ::RPI::ComputePass::InitializeInternal();
 
         m_srgNeedsUpdate = (m_shaderConstantData != nullptr);
 
-        //InitializeShaderVariant();
+        // InitializeShaderVariant();
     }
 
-    void CloudscapeComputePass::SetImageAttachmentBinding(uint32_t attachmentIndex, AZ::Data::Instance<AZ::RPI::AttachmentImage> attachmentImage)
+    void CloudscapeComputePass::SetImageAttachmentBinding(
+        uint32_t attachmentIndex, AZ::Data::Instance<AZ::RPI::AttachmentImage> attachmentImage)
     {
         const AZStd::string slotNameStr = AZStd::string::format("Output%u", attachmentIndex);
         const auto slotName = AZ::Name(slotNameStr);
@@ -65,13 +68,11 @@ namespace VolumetricClouds
         // AZ::RPI::RenderPass::InitializeInternal().
         binding->m_shaderInputName = AZ::Name("m_cloudscapeOut");
 
-        AZ::RHI::ImageViewDescriptor viewDesc = AZ::RHI::ImageViewDescriptor::Create(attachmentImage->GetDescriptor().m_format,
-            0, 0);
+        AZ::RHI::ImageViewDescriptor viewDesc = AZ::RHI::ImageViewDescriptor::Create(attachmentImage->GetDescriptor().m_format, 0, 0);
         binding->m_unifiedScopeDesc.SetAsImage(viewDesc);
 
         AttachImageToSlot(slotName, attachmentImage);
     }
-
 
     void CloudscapeComputePass::BuildInternal()
     {
@@ -82,11 +83,11 @@ namespace VolumetricClouds
             // This can happen when the feature processor is being destroyed.
             return;
         }
-
-        const auto output0ImageAttachment = cloudscapeFeatureProcessor->GetOutput0ImageAttachment();
+        std::cout << m_passIndex << std::endl;
+        const auto output0ImageAttachment = cloudscapeFeatureProcessor->GetOutput0ImageAttachment(m_passIndex);
         // Bind the first attachment
         SetImageAttachmentBinding(0, output0ImageAttachment);
-        SetImageAttachmentBinding(1, cloudscapeFeatureProcessor->GetOutput1ImageAttachment());
+        SetImageAttachmentBinding(1, cloudscapeFeatureProcessor->GetOutput1ImageAttachment(m_passIndex));
 
         const auto attachmentSize = output0ImageAttachment->GetDescriptor().m_size;
 
@@ -96,9 +97,9 @@ namespace VolumetricClouds
         // and for Y = ceil(imageHeight/4);
         // REMARK: Each frame, the feature processor will call UpdateFrameCounter(), which will
         // define the pixel index in the range 0..15.
-        
-        //const auto totalThreadsX = attachmentSize.m_width;
-        //const auto totalThreadsY = attachmentSize.m_height;
+
+        // const auto totalThreadsX = attachmentSize.m_width;
+        // const auto totalThreadsY = attachmentSize.m_height;
 
         const auto totalThreadsX = static_cast<uint32_t>(AZStd::ceil(static_cast<float>(attachmentSize.m_width) / 4.0f));
         const auto totalThreadsY = static_cast<uint32_t>(AZStd::ceil(static_cast<float>(attachmentSize.m_height) / 4.0f));
@@ -111,90 +112,96 @@ namespace VolumetricClouds
     //     AZ::RPI::ComputePass::FrameBeginInternal(params);
     // }
 
-
     // void CloudscapeComputePass::SetupFrameGraphDependencies(AZ::RHI::FrameGraphInterface frameGraph)
     // {
     //     AZ::RPI::ComputePass::SetupFrameGraphDependencies(frameGraph);
     // }
 
-    
     void CloudscapeComputePass::CompileResources(const AZ::RHI::FrameGraphCompileContext& context)
     {
-       AZ_Assert(m_shaderResourceGroup != nullptr, "CloudscapeComputePass %s has a null shader resource group when calling Compile.", GetPathName().GetCStr());
+        AZ_Assert(
+            m_shaderResourceGroup != nullptr,
+            "CloudscapeComputePass %s has a null shader resource group when calling Compile.",
+            GetPathName().GetCStr());
 
-       m_shaderResourceGroup->SetConstant(m_pixelIndex4x4Index, m_pixelIndex4x4);
+        m_shaderResourceGroup->SetConstant(m_pixelIndex4x4Index, m_pixelIndex4x4);
+        // m_pixelIndex4x4 += 1;
+        // m_pixelIndex4x4 %= 16;
+        // std::cout << "Pass" << m_pixelIndex4x4 << std::endl;
 
-       if (m_srgNeedsUpdate && m_shaderConstantData)
-       {
-           m_shaderResourceGroup->SetConstant(m_uvwScaleIndex, m_shaderConstantData->m_uvwScale);
-           m_shaderResourceGroup->SetConstant(m_maxMipLevelsIndex, m_shaderConstantData->m_clampedMipLevels);
+        if (m_srgNeedsUpdate && m_shaderConstantData)
+        {
+            m_shaderResourceGroup->SetConstant(m_uvwScaleIndex, m_shaderConstantData->m_uvwScale);
+            m_shaderResourceGroup->SetConstant(m_maxMipLevelsIndex, m_shaderConstantData->m_clampedMipLevels);
 
-           const auto minSteps = AZStd::min<uint32_t>(m_shaderConstantData->m_minRayMarchingSteps, m_shaderConstantData->m_maxRayMarchingSteps);
-           const auto maxSteps = AZStd::max<uint32_t>(m_shaderConstantData->m_minRayMarchingSteps, m_shaderConstantData->m_maxRayMarchingSteps);
-           m_shaderResourceGroup->SetConstant(m_minRayMarchingStepsIndex, minSteps);
-           m_shaderResourceGroup->SetConstant(m_maxRayMarchingStepsIndex, maxSteps);
+            const auto minSteps =
+                AZStd::min<uint32_t>(m_shaderConstantData->m_minRayMarchingSteps, m_shaderConstantData->m_maxRayMarchingSteps);
+            const auto maxSteps =
+                AZStd::max<uint32_t>(m_shaderConstantData->m_minRayMarchingSteps, m_shaderConstantData->m_maxRayMarchingSteps);
+            m_shaderResourceGroup->SetConstant(m_minRayMarchingStepsIndex, minSteps);
+            m_shaderResourceGroup->SetConstant(m_maxRayMarchingStepsIndex, maxSteps);
 
+            m_shaderResourceGroup->SetConstant(m_planetRadiusKmIndex, static_cast<float>(m_shaderConstantData->m_planetRadiusKm));
+            m_shaderResourceGroup->SetConstant(
+                m_cloudSlabDistanceAboveSeaLevelKmIndex, m_shaderConstantData->m_cloudSlabDistanceAboveSeaLevelKm);
+            m_shaderResourceGroup->SetConstant(m_cloudSlabThicknessKmIndex, m_shaderConstantData->m_cloudSlabThicknessKm);
 
-           m_shaderResourceGroup->SetConstant(m_planetRadiusKmIndex, static_cast<float>(m_shaderConstantData->m_planetRadiusKm));
-           m_shaderResourceGroup->SetConstant(m_cloudSlabDistanceAboveSeaLevelKmIndex,  m_shaderConstantData->m_cloudSlabDistanceAboveSeaLevelKm);
-           m_shaderResourceGroup->SetConstant(m_cloudSlabThicknessKmIndex, m_shaderConstantData->m_cloudSlabThicknessKm);
+            AZ::Color sunColorAndIntensity =
+                AZ::Color::CreateFromVector3AndFloat(m_shaderConstantData->m_sunColor, m_shaderConstantData->m_sunLightIntensity);
+            m_shaderResourceGroup->SetConstant(m_sunColorAndIntensityIndex, sunColorAndIntensity);
 
-           AZ::Color sunColorAndIntensity = AZ::Color::CreateFromVector3AndFloat(m_shaderConstantData->m_sunColor, m_shaderConstantData->m_sunLightIntensity);
-           m_shaderResourceGroup->SetConstant(m_sunColorAndIntensityIndex, sunColorAndIntensity);
+            AZ::Color ambientLightColorAndIntensity = m_shaderConstantData->m_ambientLightColor;
+            ambientLightColorAndIntensity.SetA(m_shaderConstantData->m_ambientLightIntensity);
+            m_shaderResourceGroup->SetConstant(m_ambientLightColorAndIntensityIndex, ambientLightColorAndIntensity);
 
-           AZ::Color ambientLightColorAndIntensity = m_shaderConstantData->m_ambientLightColor;
-           ambientLightColorAndIntensity.SetA(m_shaderConstantData->m_ambientLightIntensity);
-           m_shaderResourceGroup->SetConstant(m_ambientLightColorAndIntensityIndex, ambientLightColorAndIntensity);
-           
-           m_shaderResourceGroup->SetConstant(m_directionTowardsTheSunIndex, m_shaderConstantData->m_directionTowardsTheSun);
+            m_shaderResourceGroup->SetConstant(m_directionTowardsTheSunIndex, m_shaderConstantData->m_directionTowardsTheSun);
 
-           // The user inputs the data in [m-1], but the shader assumes all the data is computed in Km.
-           const float absorptionCoefficient = m_shaderConstantData->m_cloudMaterialProperties.m_absorptionCoefficient * (1000.0f); //* 10.0f);
-           const float scatteringCoefficient = m_shaderConstantData->m_cloudMaterialProperties.m_scatteringCoefficient * (1000.0f);// *10.0f);
-           m_shaderResourceGroup->SetConstant(m_aCoefIndex, absorptionCoefficient);
-           m_shaderResourceGroup->SetConstant(m_sCoefIndex, scatteringCoefficient);
-           m_shaderResourceGroup->SetConstant(m_henyeyGreensteinGIndex, m_shaderConstantData->m_cloudMaterialProperties.m_henyeyGreensteinG);
-           AZ::Vector3 abc(m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringA,
-               m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringB,
-               m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringC);
-           m_shaderResourceGroup->SetConstant(m_multipleScatteringABCIndex,  abc);
+            // The user inputs the data in [m-1], but the shader assumes all the data is computed in Km.
+            const float absorptionCoefficient =
+                m_shaderConstantData->m_cloudMaterialProperties.m_absorptionCoefficient * (1000.0f); //* 10.0f);
+            const float scatteringCoefficient =
+                m_shaderConstantData->m_cloudMaterialProperties.m_scatteringCoefficient * (1000.0f); // *10.0f);
+            m_shaderResourceGroup->SetConstant(m_aCoefIndex, absorptionCoefficient);
+            m_shaderResourceGroup->SetConstant(m_sCoefIndex, scatteringCoefficient);
+            m_shaderResourceGroup->SetConstant(
+                m_henyeyGreensteinGIndex, m_shaderConstantData->m_cloudMaterialProperties.m_henyeyGreensteinG);
+            AZ::Vector3 abc(
+                m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringA,
+                m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringB,
+                m_shaderConstantData->m_cloudMaterialProperties.m_multiScatteringC);
+            m_shaderResourceGroup->SetConstant(m_multipleScatteringABCIndex, abc);
 
-           m_shaderResourceGroup->SetConstant(m_weatherMapSizeKmIndex, m_shaderConstantData->m_weatherMapSizeKm);
-           m_shaderResourceGroup->SetConstant(m_globalCloudCoverageIndex, m_shaderConstantData->m_globalCloudCoverage);
-           m_shaderResourceGroup->SetConstant(m_globalCloudDensityIndex, m_shaderConstantData->m_globalCloudDensity);
+            m_shaderResourceGroup->SetConstant(m_weatherMapSizeKmIndex, m_shaderConstantData->m_weatherMapSizeKm);
+            m_shaderResourceGroup->SetConstant(m_globalCloudCoverageIndex, m_shaderConstantData->m_globalCloudCoverage);
+            m_shaderResourceGroup->SetConstant(m_globalCloudDensityIndex, m_shaderConstantData->m_globalCloudDensity);
 
-           AZ::Vector3 windDirection = m_shaderConstantData->m_windDirection;
-           const float windDirectionLength = windDirection.GetLength();
-           windDirection = AZ::IsClose(windDirectionLength, 0.0f, 0.01f)
-               ? AZ::Vector3::CreateZero()
-               : (windDirection / windDirectionLength);
-           m_shaderResourceGroup->SetConstant(m_windSpeedKmPerSecIndex, m_shaderConstantData->m_windSpeedKmPerSec);
-           m_shaderResourceGroup->SetConstant(m_windDirectionIndex, windDirection);
-           m_shaderResourceGroup->SetConstant(m_cloudTopOffsetKmIndex, m_shaderConstantData->m_cloudTopOffsetKm);
+            AZ::Vector3 windDirection = m_shaderConstantData->m_windDirection;
+            const float windDirectionLength = windDirection.GetLength();
+            windDirection =
+                AZ::IsClose(windDirectionLength, 0.0f, 0.01f) ? AZ::Vector3::CreateZero() : (windDirection / windDirectionLength);
+            m_shaderResourceGroup->SetConstant(m_windSpeedKmPerSecIndex, m_shaderConstantData->m_windSpeedKmPerSec);
+            m_shaderResourceGroup->SetConstant(m_windDirectionIndex, windDirection);
+            m_shaderResourceGroup->SetConstant(m_cloudTopOffsetKmIndex, m_shaderConstantData->m_cloudTopOffsetKm);
 
-           m_shaderResourceGroup->SetImage(m_lowFreqNoiseTextureImageIndex, m_shaderConstantData->m_lowFrequencyNoiseTexture);
-           m_shaderResourceGroup->SetImage(m_highFreqNoiseTextureImageIndex, m_shaderConstantData->m_highFrequencyNoiseTexture);
-           m_shaderResourceGroup->SetImage(m_weatherMapImageIndex, m_shaderConstantData->m_weatherMap);
+            m_shaderResourceGroup->SetImage(m_lowFreqNoiseTextureImageIndex, m_shaderConstantData->m_lowFrequencyNoiseTexture);
+            m_shaderResourceGroup->SetImage(m_highFreqNoiseTextureImageIndex, m_shaderConstantData->m_highFrequencyNoiseTexture);
+            m_shaderResourceGroup->SetImage(m_weatherMapImageIndex, m_shaderConstantData->m_weatherMap);
 
-           m_srgNeedsUpdate = false;
-       }
+            m_srgNeedsUpdate = false;
+        }
 
-       AZ::RPI::ComputePass::CompileResources(context);
+        AZ::RPI::ComputePass::CompileResources(context);
     }
-    
-    
+
     // void CloudscapeComputePass::BuildCommandListInternal(const AZ::RHI::FrameGraphExecuteContext& context)
     // {
     //     AZ::RPI::ComputePass::BuildCommandListInternal(context);
     // }
 
-
     void CloudscapeComputePass::UpdateShaderConstantData(const CloudscapeShaderConstantData& shaderData)
     {
         // If any of the textures is nullptr we disable this pass.
-        if (!shaderData.m_lowFrequencyNoiseTexture ||
-            !shaderData.m_highFrequencyNoiseTexture ||
-            !shaderData.m_weatherMap)
+        if (!shaderData.m_lowFrequencyNoiseTexture || !shaderData.m_highFrequencyNoiseTexture || !shaderData.m_weatherMap)
         {
             m_shaderConstantData = nullptr;
             SetEnabled(false);
@@ -210,10 +217,14 @@ namespace VolumetricClouds
         }
     }
 
-
     void CloudscapeComputePass::UpdateFrameCounter(uint32_t frameCounter)
     {
         m_pixelIndex4x4 = frameCounter % 16;
     }
 
-}   // VolumetricClouds AZ
+    void CloudscapeComputePass::SetPassIndex(unsigned int passIndex)
+    {
+        m_passIndex = passIndex;
+    }
+
+} // namespace VolumetricClouds

--- a/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.h
+++ b/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.h
@@ -1,9 +1,9 @@
 /*
-* Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
-*
-* SPDX-License-Identifier: Apache-2.0 OR MIT
-*
-*/
+ * Copyright (c) Galib Arrieta (aka lumbermixalot@github, aka galibzon@github).
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
 #pragma once
 
 #include <AzCore/Memory/SystemAllocator.h>
@@ -12,10 +12,10 @@
 #include <Atom/RHI/DrawItem.h>
 #include <Atom/RHI/ScopeProducer.h>
 
+#include <Atom/RPI.Public/Image/StreamingImage.h>
 #include <Atom/RPI.Public/Pass/ComputePass.h>
 #include <Atom/RPI.Public/Shader/Shader.h>
 #include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
-#include <Atom/RPI.Public/Image/StreamingImage.h>
 
 #include <Renderer/CloudscapeShaderConstantData.h>
 
@@ -31,24 +31,29 @@ namespace VolumetricClouds
      *  When we are rendering to the current frame we only render to 1 of 16 pixels
      *  in a 4x4 block.
      */
-    class CloudscapeComputePass final
-        : public AZ::RPI::ComputePass
+    class CloudscapeComputePass final : public AZ::RPI::ComputePass
     {
         AZ_RPI_PASS(CloudscapeComputePass);
 
     public:
         AZ_RTTI(CloudscapeComputePass, "{ECB96676-7F1B-41E5-9C5F-89EA02FD116E}", AZ::RPI::ComputePass);
         AZ_CLASS_ALLOCATOR(CloudscapeComputePass, AZ::SystemAllocator);
-    
-    
-        virtual ~CloudscapeComputePass();// = default;
-    
+
+        virtual ~CloudscapeComputePass(); // = default;
+
         static AZ::RPI::Ptr<CloudscapeComputePass> Create(const AZ::RPI::PassDescriptor& descriptor);
 
         void UpdateShaderConstantData(const CloudscapeShaderConstantData& shaderData);
 
         void UpdateFrameCounter(uint32_t frameCounter);
-    
+
+        void SetPassIndex(unsigned int passIndex);
+
+        inline uint32_t GetPixelIndex() const
+        {
+            return m_pixelIndex4x4;
+        }
+
     private:
         CloudscapeComputePass(const AZ::RPI::PassDescriptor& descriptor);
 
@@ -64,10 +69,12 @@ namespace VolumetricClouds
 
         // A helper function
         void SetImageAttachmentBinding(uint32_t attachmentIndex, AZ::Data::Instance<AZ::RPI::AttachmentImage> attachmentImage);
-    
+
         bool m_srgNeedsUpdate = true;
         const CloudscapeShaderConstantData* m_shaderConstantData = nullptr;
         uint32_t m_pixelIndex4x4 = 0; // Frame Counter % 16.
+
+        unsigned int m_passIndex = 0;
 
         AZ::RHI::ShaderInputNameIndex m_pixelIndex4x4Index = "m_pixelIndex4x4";
 
@@ -99,7 +106,6 @@ namespace VolumetricClouds
         AZ::RHI::ShaderInputNameIndex m_lowFreqNoiseTextureImageIndex = "m_lowFreqNoiseTexture";
         AZ::RHI::ShaderInputNameIndex m_highFreqNoiseTextureImageIndex = "m_highFreqNoiseTexture";
         AZ::RHI::ShaderInputNameIndex m_weatherMapImageIndex = "m_weatherMap";
-
     };
 
-}   // namespace VolumetricClouds
+} // namespace VolumetricClouds

--- a/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.h
+++ b/Gem/Code/Source/Renderer/Passes/CloudscapeComputePass.h
@@ -47,8 +47,10 @@ namespace VolumetricClouds
 
         void UpdateFrameCounter(uint32_t frameCounter);
 
+        // Sets the index of the pass. This enables the pass to know which attachment to write to.
         void SetPassIndex(unsigned int passIndex);
 
+        // Returns the last rendered pixel index in the 4x4 block.
         inline uint32_t GetPixelIndex() const
         {
             return m_pixelIndex4x4;
@@ -73,7 +75,6 @@ namespace VolumetricClouds
         bool m_srgNeedsUpdate = true;
         const CloudscapeShaderConstantData* m_shaderConstantData = nullptr;
         uint32_t m_pixelIndex4x4 = 0; // Frame Counter % 16.
-
         unsigned int m_passIndex = 0;
 
         AZ::RHI::ShaderInputNameIndex m_pixelIndex4x4Index = "m_pixelIndex4x4";


### PR DESCRIPTION
I've added support for multiple pipelines for rendering clouds. This enables clouds in ROS2 cameras.

This modifies this gem to enable the creation of multiple passes that are connected to a pipeline.

~As of now an additional modification is required in the ROS2 camera component to visualize the clouds. The 
```pipelineDesc.m_allowModification = false;```
flag needs to be set in the ROS2 camera.~