### PR TITLE
Fix cmake problem (see o3de#17605)

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -127,7 +127,7 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
         BUILD_DEPENDENCIES
             PUBLIC
                 AZ::AzToolsFramework
-                $<TARGET_OBJECTS:Gem::${gem_name}.Private.Object>
+                ${gem_name}.Private.Object
                 Gem::Atom_Feature_Common.Public
                 Gem::AtomLyIntegration_CommonFeatures.Public
                 Gem::Atom_Utils.Static


### PR DESCRIPTION
There used to be a problem with gem generator which makes gems impossible to build with newer `cmake` tools. Please see https://github.com/o3de/o3de/pull/17605 for details.